### PR TITLE
【feat】多路召回数据存储列表

### DIFF
--- a/src/main/java/com/search/docsearch/multirecall/composite/Component.java
+++ b/src/main/java/com/search/docsearch/multirecall/composite/Component.java
@@ -1,0 +1,28 @@
+/* Copyright (c) 2024 openEuler Community
+ EasySoftware is licensed under the Mulan PSL v2.
+ You can use this software according to the terms and conditions of the Mulan PSL v2.
+ You may obtain a copy of Mulan PSL v2 at:
+     http://license.coscl.org.cn/MulanPSL2
+ THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ See the Mulan PSL v2 for more details.
+*/
+package com.search.docsearch.multirecall.composite;
+import java.util.Map;
+
+public interface Component {
+ 
+    /**
+     * roughly filter the recalled results
+     * 
+     * @param filterPolicy strategy for filtering recall results
+     */
+    void filter(String filterPolicy) throws RuntimeException;
+
+    /**
+     * return the recall list to client
+     * 
+     */
+    Map<String, Object> getResList();
+}

--- a/src/main/java/com/search/docsearch/multirecall/composite/DataComposite.java
+++ b/src/main/java/com/search/docsearch/multirecall/composite/DataComposite.java
@@ -1,0 +1,90 @@
+/* Copyright (c) 2024 openEuler Community
+ EasySoftware is licensed under the Mulan PSL v2.
+ You can use this software according to the terms and conditions of the Mulan PSL v2.
+ You may obtain a copy of Mulan PSL v2 at:
+     http://license.coscl.org.cn/MulanPSL2
+ THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ See the Mulan PSL v2 for more details.
+*/
+package com.search.docsearch.multirecall.composite;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+ 
+public class DataComposite implements Component {
+
+    /**
+     * logger.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(Component.class);
+    
+    /**
+     * Recall results list.
+     */
+    private List<Component> children = new ArrayList<>();
+ 
+    /**
+     * roughly filter the recalled results
+     * 
+     * @param filterPolicy strategy for filtering recall results
+     */
+    @Override
+    public void filter(String filterPolicy) {
+        for (Component child : children) {
+            try {
+                child.filter(filterPolicy);
+            } catch (RuntimeException e) {
+                LOGGER.error("catch unexcepted error when flitering the data");
+            }
+        }
+    }
+
+    /**
+     * return the recall list to client
+     * 
+     */
+    @Override
+    public Map<String, Object> getResList(){
+        throw new UnsupportedOperationException("composite do not have reslist");
+    }
+
+    /**
+     * add component into DataComposite
+     * 
+     * @param component strategy for filtering recall results
+     */
+    public void add(Component component) {
+        children.add(component);
+    }
+
+    /**
+     * remove component from DataComposite
+     * 
+     * @param component strategy for filtering recall results
+     */
+    public void remove(Component component) {
+        children.remove(component);
+    }
+
+     /**
+     * return the idx to client
+     * 
+     * @param idx strategy for filtering recall results
+     */
+    public Component getChild(int idx) {
+        return children.get(idx);
+    }
+
+    /**
+     * return the size of res list
+     * 
+     */
+    public int getSize(){
+        return children.size();
+    }
+}

--- a/src/main/java/com/search/docsearch/multirecall/composite/cdata/EsRecallData.java
+++ b/src/main/java/com/search/docsearch/multirecall/composite/cdata/EsRecallData.java
@@ -1,0 +1,58 @@
+/* Copyright (c) 2024 openEuler Community
+ EasySoftware is licensed under the Mulan PSL v2.
+ You can use this software according to the terms and conditions of the Mulan PSL v2.
+ You may obtain a copy of Mulan PSL v2 at:
+     http://license.coscl.org.cn/MulanPSL2
+ THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ See the Mulan PSL v2 for more details.
+*/
+package com.search.docsearch.multirecall.composite.cdata;
+
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.search.docsearch.multirecall.composite.Component;
+
+public class EsRecallData implements Component {
+    /**
+     * logger.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(EsRecallData.class);
+    
+    /**
+     * search entities of es recall
+     */
+    private Map<String, Object> recallList;
+ 
+    /**
+     * constructor of esRecall data
+     * 
+     * @param recallList 
+     */
+    public EsRecallData(Map<String, Object> recallList) {
+        this.recallList = recallList;
+    }
+    
+    /**
+     * roughly filter the recalled results
+     * 
+     * @param filterPolicy strategy for filtering recall results
+     */
+    @Override
+    public void filter(String filterPolicy) throws RuntimeException {
+       //writing filter logic here
+    }
+
+    /**
+     * return the recall list to client
+     * 
+     */
+    @Override
+    public Map<String, Object> getResList(){
+        return this.recallList;
+    }
+}

--- a/src/main/java/com/search/docsearch/multirecall/composite/cdata/GRecallData.java
+++ b/src/main/java/com/search/docsearch/multirecall/composite/cdata/GRecallData.java
@@ -1,0 +1,57 @@
+/* Copyright (c) 2024 openEuler Community
+ EasySoftware is licensed under the Mulan PSL v2.
+ You can use this software according to the terms and conditions of the Mulan PSL v2.
+ You may obtain a copy of Mulan PSL v2 at:
+     http://license.coscl.org.cn/MulanPSL2
+ THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ See the Mulan PSL v2 for more details.
+*/
+package com.search.docsearch.multirecall.composite.cdata;
+
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.search.docsearch.multirecall.composite.Component;
+
+public class GRecallData implements Component{
+    /**
+     * logger.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(GRecallData.class);
+    
+    /**
+     * search entities of es recall, 
+     */
+    private Map<String, Object> recallList;
+ 
+    /**
+     * constructor of esRecall data
+     * 
+     * @param recallList 
+     */
+    public GRecallData(Map<String, Object> recallList) {
+        this.recallList = recallList;
+    }
+    
+    /**
+     * set an ApplyHandleRecord entity createAt field value.
+     *
+     * @param criteria The ApplicationPackageDO entity  createAt field for set
+     */
+    @Override
+    public void filter(String filterPolicy) throws RuntimeException {
+        //writing filter logic here
+    }
+
+    /**
+     * return the recall list to client
+     * 
+     */
+    @Override
+    public Map<String, Object> getResList(){
+        //writing filter logic here
+        return null;
+    }
+}

--- a/src/test/java/com/search/docsearch/CompositeTest.java
+++ b/src/test/java/com/search/docsearch/CompositeTest.java
@@ -1,0 +1,106 @@
+/* Copyright (c) 2024 openEuler Community
+ EasySoftware is licensed under the Mulan PSL v2.
+ You can use this software according to the terms and conditions of the Mulan PSL v2.
+ You may obtain a copy of Mulan PSL v2 at:
+     http://license.coscl.org.cn/MulanPSL2
+ THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ See the Mulan PSL v2 for more details.
+*/
+package com.search.docsearch;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.search.docsearch.multirecall.composite.Component;
+import com.search.docsearch.multirecall.composite.DataComposite;
+import com.search.docsearch.multirecall.composite.cdata.EsRecallData;
+import com.search.docsearch.multirecall.composite.cdata.GRecallData;
+
+import java.util.Collections;
+@SpringBootTest
+public class CompositeTest {
+    
+    /**
+      * 测试: 多路召回结果获取
+    */
+    @Test
+    void testGetChild() {
+        DataComposite dataComposite = new DataComposite();
+        Component mockComponent1 = new EsRecallData(Collections.emptyMap());
+        Component mockComponent2 = new GRecallData(Collections.emptyMap());
+        
+        dataComposite.add(mockComponent1);
+        dataComposite.add(mockComponent2);
+        assertEquals(mockComponent1, dataComposite.getChild(0));
+        assertEquals(mockComponent2, dataComposite.getChild(1));
+    }
+
+    /**
+      * 测试: 多路召回结果获取下标越界
+    */
+    @Test
+    void testGetChildWithError() {
+        DataComposite dataComposite = new DataComposite();
+        Component mockComponent1 = new EsRecallData(Collections.emptyMap());
+        Component mockComponent2 = new GRecallData(Collections.emptyMap());
+        
+        dataComposite.add(mockComponent1);
+        dataComposite.add(mockComponent2);
+
+        IndexOutOfBoundsException exception = assertThrows(
+            IndexOutOfBoundsException.class,
+                () -> dataComposite.getChild(2));
+        assertEquals("Index 2 out of bounds for length 2",exception.getMessage());        
+    }
+
+    /**
+      * 测试: 多路召回列表错误操作
+    */
+    @Test
+    void testGetReslistWithError() {
+        DataComposite dataComposite = new DataComposite();
+    
+        UnsupportedOperationException exception = assertThrows(
+            UnsupportedOperationException.class,
+                () -> dataComposite.getResList());
+        assertEquals("composite do not have reslist",exception.getMessage());        
+    }
+
+    /**
+      * 测试: 多路召回列表移除
+    */
+    @Test
+    void testRemoveComponent() {
+        DataComposite dataComposite = new DataComposite();
+        Component mockComponent1 = new EsRecallData(Collections.emptyMap());
+        Component mockComponent2 = new GRecallData(Collections.emptyMap());
+
+        dataComposite.add(mockComponent1);
+        dataComposite.add(mockComponent2);
+        dataComposite.remove(mockComponent1);
+        assertEquals(1, dataComposite.getSize());
+    }
+
+    /**
+      * 测试: 多路召回结果粗筛异常测试
+    */
+    @Test
+    void testFliteringRecallWithError() {
+        DataComposite dataComposite = new DataComposite();
+        Component mockComponent = new EsRecallData(Collections.emptyMap());
+        Component errorComponent = new TestRecallData(Collections.emptyMap());
+        dataComposite.add(mockComponent);
+        dataComposite.add(errorComponent);
+
+        RuntimeException exception = assertThrows(
+            RuntimeException.class,
+                () -> errorComponent.filter(null));
+
+        assertEquals("error when process the recall res",exception.getMessage());    
+    }
+
+}

--- a/src/test/java/com/search/docsearch/TestRecallData.java
+++ b/src/test/java/com/search/docsearch/TestRecallData.java
@@ -1,0 +1,53 @@
+/* Copyright (c) 2024 openEuler Community
+ EasySoftware is licensed under the Mulan PSL v2.
+ You can use this software according to the terms and conditions of the Mulan PSL v2.
+ You may obtain a copy of Mulan PSL v2 at:
+     http://license.coscl.org.cn/MulanPSL2
+ THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ See the Mulan PSL v2 for more details.
+*/
+package com.search.docsearch;
+
+
+import java.util.Map;
+
+import com.search.docsearch.multirecall.composite.Component;
+
+public class TestRecallData implements Component{
+
+    /**
+     * search entities of es recall, 
+     */
+    private Map<String, Object> recallList;
+ 
+    /**
+     * constructor of esRecall data
+     * 
+     * @param recallList 
+     */
+    public TestRecallData(Map<String, Object> recallList) {
+        this.recallList = recallList;
+    }
+    
+    /**
+     * set an ApplyHandleRecord entity createAt field value.
+     *
+     * @param criteria The ApplicationPackageDO entity  createAt field for set
+     */
+    @Override
+    public void filter(String filterPolicy) throws RuntimeException {
+        throw new RuntimeException("error when process the recall res");
+    }
+
+    /**
+     * return the recall list to client
+     * 
+     */
+    @Override
+    public Map<String, Object> getResList(){
+        //writing filter logic here
+        return null;
+    }
+}


### PR DESCRIPTION
使用组合模式存储多路召回结果，叶子节点存储结果并执行业务粗筛逻辑，容器组合叶子节点
src/main/java/com/search/docsearch/multirecall/composite/Component.java 组合接口类
src/main/java/com/search/docsearch/multirecall/composite/DataComposite.java 容器类
src/main/java/com/search/docsearch/multirecall/composite/cdata/EsRecallData.java es索引召回结果与粗筛逻辑框架
src/main/java/com/search/docsearch/multirecall/composite/cdata/GRecallData.java google召回结果与粗筛逻辑框架
src/test/java/com/search/docsearch/CompositeTest.java  容器单元测试
src/test/java/com/search/docsearch/TestRecallData.java  异常结果类，用于模拟粗筛业务执行失败