### PR TITLE
【feat】多路召回框架与es召回

### DIFF
--- a/src/main/java/com/search/docsearch/multirecall/recall/MultiSearchContext.java
+++ b/src/main/java/com/search/docsearch/multirecall/recall/MultiSearchContext.java
@@ -1,0 +1,70 @@
+/* Copyright (c) 2024 openEuler Community
+ EasySoftware is licensed under the Mulan PSL v2.
+ You can use this software according to the terms and conditions of the Mulan PSL v2.
+ You may obtain a copy of Mulan PSL v2 at:
+     http://license.coscl.org.cn/MulanPSL2
+ THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ See the Mulan PSL v2 for more details.
+*/
+package com.search.docsearch.multirecall.recall;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.search.docsearch.entity.vo.SearchCondition;
+import com.search.docsearch.multirecall.composite.DataComposite;
+import com.search.docsearch.multirecall.composite.Component;
+
+public class MultiSearchContext {
+    /**
+     * logger.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(MultiSearchContext.class);
+    
+
+    /**
+     * List to store the search starteys
+     * 
+     */
+    private List<SearchStrategy> searchStrategys = new ArrayList<>();
+    
+    /**
+     * set Search Strategy into contex
+     * 
+     * @param SearchCondition 
+     */
+    public void setSearchStrategy(SearchStrategy searchStrategy) {
+        this.searchStrategys.add(searchStrategy);
+    }
+
+    /**
+     * excute multirecall on same query condition
+     * 
+     * @param SearchCondition the search query of user 
+     */
+    public DataComposite executeMultiSearch(SearchCondition condition) {
+        DataComposite res = new DataComposite();
+        for(SearchStrategy searchStgy : searchStrategys){
+            //do recall, the validtaion of condition should implement by concrte strategy
+            Component recallRes = searchStgy.search(condition);
+            //in case one way does't recall anything  
+            if (recallRes != null){
+                res.add(recallRes);
+            }
+        }
+        return res;
+    }
+
+    /**
+     * return the current registerd recall strategys
+     * 
+     */
+    public int getMultiRecalls() {
+        return searchStrategys.size();
+    }
+}

--- a/src/main/java/com/search/docsearch/multirecall/recall/SearchStrategy.java
+++ b/src/main/java/com/search/docsearch/multirecall/recall/SearchStrategy.java
@@ -1,0 +1,23 @@
+/* Copyright (c) 2024 openEuler Community
+ EasySoftware is licensed under the Mulan PSL v2.
+ You can use this software according to the terms and conditions of the Mulan PSL v2.
+ You may obtain a copy of Mulan PSL v2 at:
+     http://license.coscl.org.cn/MulanPSL2
+ THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ See the Mulan PSL v2 for more details.
+*/
+package com.search.docsearch.multirecall.recall;
+
+import com.search.docsearch.entity.vo.SearchCondition;
+import com.search.docsearch.multirecall.composite.Component;
+
+public interface SearchStrategy {
+    /**
+     * search interface, recall the result according to user query
+     * 
+     * @param SearchCondition 
+     */
+    Component search(SearchCondition condition);
+}

--- a/src/main/java/com/search/docsearch/multirecall/recall/cstrategy/EsSearchStrategy.java
+++ b/src/main/java/com/search/docsearch/multirecall/recall/cstrategy/EsSearchStrategy.java
@@ -1,0 +1,293 @@
+/* Copyright (c) 2024 openEuler Community
+ EasySoftware is licensed under the Mulan PSL v2.
+ You can use this software according to the terms and conditions of the Mulan PSL v2.
+ You may obtain a copy of Mulan PSL v2 at:
+     http://license.coscl.org.cn/MulanPSL2
+ THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ See the Mulan PSL v2 for more details.
+*/
+package com.search.docsearch.multirecall.recall.cstrategy;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.common.lucene.search.function.CombineFunction;
+import org.elasticsearch.common.lucene.search.function.FunctionScoreQuery;
+import org.elasticsearch.common.text.Text;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.MatchPhraseQueryBuilder;
+import org.elasticsearch.index.query.MatchQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.functionscore.FunctionScoreQueryBuilder;
+import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder;
+import org.elasticsearch.search.fetch.subphase.highlight.HighlightField;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.StringUtils;
+import org.springframework.web.util.HtmlUtils;
+import com.search.docsearch.utils.Trie;
+import com.search.docsearch.config.EsfunctionScoreConfig;
+import com.search.docsearch.entity.vo.SearchCondition;
+import com.search.docsearch.except.ServiceImplException;
+import com.search.docsearch.multirecall.composite.Component;
+import com.search.docsearch.multirecall.composite.cdata.EsRecallData;
+import com.search.docsearch.multirecall.recall.SearchStrategy;
+import com.search.docsearch.utils.General;
+import org.elasticsearch.client.RestHighLevelClient;
+
+
+public class EsSearchStrategy implements SearchStrategy {
+    /**
+     * logger.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(SearchStrategy.class);
+
+    /**
+     * return the recall list to client
+     * 
+     */
+    private RestHighLevelClient restHighLevelClient;
+
+    /**
+     * es index 
+     * 
+     */
+    private String index;
+
+    /**
+     * algorithm util
+     * 
+     */
+    private Trie trie;
+
+    /**
+     * boost socre config, ranking the recall list
+     * 
+     */
+    private EsfunctionScoreConfig esfunctionScoreConfig;
+
+    /**
+     * roughly filter the recalled results
+     * 
+     * @param pararestHighLevelClient paraClient mannage by spring aoc
+     * @param paraindex the index of es search 
+     * @param paratire the algorithim toolkit
+     * @param config the boost socre config which used to ranking the result list
+     */
+    public EsSearchStrategy(RestHighLevelClient pararestHighLevelClient, String paraindex, Trie paratire,EsfunctionScoreConfig config){
+        this.restHighLevelClient = pararestHighLevelClient;
+        this.index = paraindex;
+        this.trie = paratire;
+        this.esfunctionScoreConfig = config;
+    }
+
+    /**
+     * wrapper of the funcition search 
+     * 
+     * @param SearchCondition the user query
+     */
+    @Override
+    public Component search(SearchCondition condition) {
+        EsRecallData emptyRes = new EsRecallData(Collections.emptyMap()); //空返回
+        try{
+            Component EsRecallData = searchByCondition(condition);
+            return EsRecallData == null ? emptyRes : EsRecallData; //遇到正常0召回情况，返回空结果
+        } catch (ServiceImplException e){ // 遇到异常不中断 返回空结果
+            return emptyRes;
+        }
+    }
+
+    /**
+     * doing the recall according user query 
+     * 
+     * @param SearchCondition the user query
+     */
+    private Component searchByCondition(SearchCondition condition) throws ServiceImplException {
+        String saveIndex = index + "_" + condition.getLang();
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("keyword", HtmlUtils.htmlEscape(condition.getKeyword()));
+
+        SearchRequest request = BuildSearchRequest(condition, saveIndex);
+        SearchResponse response = null;
+        try {
+            response = restHighLevelClient.search(request, RequestOptions.DEFAULT);
+        } catch (IOException e) {
+            throw new ServiceImplException("can not search");
+        }
+        List<Map<String, Object>> data = new ArrayList<>();
+
+        for (SearchHit hit : response.getHits().getHits()) {
+            Map<String, Object> map = hit.getSourceAsMap();
+            String text = (String) map.getOrDefault("textContent", "");
+            if (null != text && text.length() > 200) {
+                text = text.substring(0, 200) + "......";
+            }
+            map.put("textContent", text);
+            Map<String, HighlightField> highlightFields = hit.getHighlightFields();
+            if (highlightFields.containsKey("textContent")) {
+                StringBuilder highLight = new StringBuilder();
+                for (Text textContent : highlightFields.get("textContent").getFragments()) {
+                    highLight.append(textContent.toString()).append("<br>");
+                }
+                map.put("textContent", highLight.toString());
+            }
+            if ("whitepaper".equals(map.getOrDefault("type", "")) && !map.containsKey("title")) {
+                map.put("title", map.get("secondaryTitle"));
+            }
+            if ("service".equals(map.getOrDefault("type", ""))) {
+                map.put("secondaryTitle", map.get("textContent"));
+            }
+            if (condition.getPage() == 1) {
+                Float score = hit.getScore();
+                Double scoreTopSearch = score * trie.getWordSimilarityWithTopSearch(String.valueOf(map.get("title")), 10);
+                if (!(Math.abs(scoreTopSearch - 0.0) < 1e-6f)) {
+                    map.put("score", scoreTopSearch);
+                }
+                else {
+                    map.put("score", score*1.0);
+                }
+            }
+            if (highlightFields.containsKey("title")) {
+                map.put("title", highlightFields.get("title").getFragments()[0].toString());
+            }
+
+            data.add(map);
+        }
+        if (data.isEmpty()) {
+            return null;
+        }
+        if (condition.getPage() == 1) {
+            data = data.stream().sorted((a, b) -> Double.compare((Double) b.get("score"), (Double) a.get("score"))).collect(Collectors.toList());
+        }
+        result.put("page", condition.getPage());
+        result.put("pageSize", condition.getPageSize());
+        result.put("records", data);
+
+        EsRecallData resData = new EsRecallData(result);
+        
+        return resData;
+    }
+
+    /**
+     * build the es qeury from search condition 
+     * 
+     * @param condition the user query
+     * @param index the search index
+     */
+    private SearchRequest BuildSearchRequest(SearchCondition condition, String index) {
+        int startIndex = (condition.getPage() - 1) * condition.getPageSize();
+        SearchRequest request = new SearchRequest(index);
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+        BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery();
+
+        if (StringUtils.hasText(condition.getType())) {
+            boolQueryBuilder.filter(QueryBuilders.termsQuery("type.keyword",  condition.getType().split(",")));
+        }
+        //因为会出现一些特殊的字符导致分词出错（比如英文连接词），在这里处理一下
+        condition.setKeyword(General.replacementCharacter(condition.getKeyword()));
+
+        MatchPhraseQueryBuilder ptitleMP = QueryBuilders.matchPhraseQuery("title", condition.getKeyword()).analyzer("ik_max_word").slop(2);
+        ptitleMP.boost(esfunctionScoreConfig.titleBoost == null ? 1000 : esfunctionScoreConfig.titleBoost);
+        MatchPhraseQueryBuilder ph1MP = QueryBuilders.matchPhraseQuery("h1", condition.getKeyword()).analyzer("ik_max_word");
+        ph1MP.boost(esfunctionScoreConfig.h1Boost == null ? 900 : esfunctionScoreConfig.h1Boost);
+        MatchPhraseQueryBuilder ph2MP = QueryBuilders.matchPhraseQuery("h2", condition.getKeyword()).analyzer("ik_max_word");
+        ph2MP.boost(esfunctionScoreConfig.h2Boost == null ? 800 : esfunctionScoreConfig.h2Boost);
+        MatchPhraseQueryBuilder ph3MP = QueryBuilders.matchPhraseQuery("h3", condition.getKeyword()).analyzer("ik_max_word");
+        ph3MP.boost(esfunctionScoreConfig.h3Boost == null ? 700 : esfunctionScoreConfig.h3Boost);
+        MatchPhraseQueryBuilder ph4MP = QueryBuilders.matchPhraseQuery("h4", condition.getKeyword()).analyzer("ik_max_word");
+        ph4MP.boost(esfunctionScoreConfig.h4Boost == null ? 600 : esfunctionScoreConfig.h4Boost);
+        MatchPhraseQueryBuilder ph5MP = QueryBuilders.matchPhraseQuery("h5", condition.getKeyword()).analyzer("ik_max_word");
+        ph5MP.boost(esfunctionScoreConfig.h5Boost == null ? 500 : esfunctionScoreConfig.h5Boost);
+        MatchPhraseQueryBuilder pstrongMP = QueryBuilders.matchPhraseQuery("strong", condition.getKeyword()).analyzer("ik_max_word");
+        pstrongMP.boost(esfunctionScoreConfig.strongBoost == null ? 150 : esfunctionScoreConfig.strongBoost);
+
+        MatchPhraseQueryBuilder ptextContentMP = QueryBuilders.matchPhraseQuery("textContent", condition.getKeyword()).analyzer("ik_max_word").slop(2);
+        ptextContentMP.boost(esfunctionScoreConfig.textContentBoost == null ? 100 : esfunctionScoreConfig.textContentBoost);
+
+        boolQueryBuilder.should(ptitleMP).should(ph1MP).should(ph2MP).should(ph3MP).should(ph4MP).should(ph5MP).should(pstrongMP).should(ptextContentMP);
+        MatchQueryBuilder titleMP = QueryBuilders.matchQuery("title", condition.getKeyword()).analyzer("ik_smart");
+        titleMP.boost(2);
+        MatchQueryBuilder textContentMP = QueryBuilders.matchQuery("textContent", condition.getKeyword()).analyzer("ik_smart");
+        textContentMP.boost(1);
+        boolQueryBuilder.should(titleMP).should(textContentMP);
+
+        boolQueryBuilder.minimumShouldMatch(1);
+
+        if (esfunctionScoreConfig.limitType == null || StringUtils.isEmpty(condition.getType()) || esfunctionScoreConfig.limitType.contains(condition.getType()))
+            if (condition.getLimit() != null) {
+                for (Map<String, String> map : condition.getLimit()) {
+                    BoolQueryBuilder vBuilder = QueryBuilders.boolQuery();
+                    for (Map.Entry<String, String> entry : map.entrySet()) {
+                        String key = entry.getKey();
+                        String value = entry.getValue();
+                        if (key.equals("version")) {
+                            String[] versions = value.split(",");
+                            vBuilder.mustNot(QueryBuilders.termsQuery("version.keyword", versions));
+                        } else {
+                            vBuilder.must(QueryBuilders.termQuery(key + ".keyword", value));
+                        }
+                    }
+                    boolQueryBuilder.mustNot(vBuilder);
+                }
+            }
+
+        if (condition.getFilter() != null) {
+            BoolQueryBuilder zBuilder = QueryBuilders.boolQuery();
+            for (Map<String, String> map : condition.getFilter()) {
+                BoolQueryBuilder vBuilder = QueryBuilders.boolQuery();
+                for (Map.Entry<String, String> entry : map.entrySet()) {
+                    String key = entry.getKey();
+                    String value = entry.getValue();
+                    if (key.equals("version")) {
+                        String[] versions = value.split(",");
+                        vBuilder.must(QueryBuilders.termsQuery("version.keyword", versions));
+                    } else {
+                        vBuilder.must(QueryBuilders.termQuery(key + ".keyword", value));
+                    }
+                }
+                zBuilder.should(vBuilder);
+            }
+            boolQueryBuilder.filter(zBuilder);
+        }
+
+        if ((condition.getType() == null || "".equals(condition.getType().trim())) && esfunctionScoreConfig.functionscore != null && esfunctionScoreConfig.functionscore.size() > 0) {
+            FunctionScoreQueryBuilder.FilterFunctionBuilder[] functionBuilder = new FunctionScoreQueryBuilder.FilterFunctionBuilder[esfunctionScoreConfig.functionscore.size()];
+            for (int i = 0; i < esfunctionScoreConfig.functionscore.size(); i++) {
+                Map<String, Object> eachFilter = esfunctionScoreConfig.functionscore.get(i);
+                functionBuilder[i] = new FunctionScoreQueryBuilder.FilterFunctionBuilder(QueryBuilders.termQuery(eachFilter.get("termkey").toString(), eachFilter.get("value")), ScoreFunctionBuilders.weightFactorFunction(Float.parseFloat(String.valueOf(eachFilter.get("weight")))));
+            }
+            FunctionScoreQueryBuilder functionScoreQuery = QueryBuilders.functionScoreQuery(boolQueryBuilder, functionBuilder)
+                    .scoreMode(FunctionScoreQuery.ScoreMode.SUM)
+                    .boostMode(CombineFunction.MULTIPLY);
+            sourceBuilder.query(functionScoreQuery);
+
+        } else {
+            sourceBuilder.query(boolQueryBuilder);
+        }
+        HighlightBuilder highlightBuilder = new HighlightBuilder()
+                .field("textContent")
+                .field("title")
+                .fragmentSize(100)
+                .preTags("<span>")
+                .postTags("</span>");
+        sourceBuilder.highlighter(highlightBuilder);
+        sourceBuilder.from(startIndex).size(condition.getPageSize());
+        sourceBuilder.timeout(TimeValue.timeValueMinutes(1L));
+        request.source(sourceBuilder);
+        return request;
+    }
+}

--- a/src/main/java/com/search/docsearch/multirecall/recall/cstrategy/GSearchStrategy.java
+++ b/src/main/java/com/search/docsearch/multirecall/recall/cstrategy/GSearchStrategy.java
@@ -1,0 +1,36 @@
+/* Copyright (c) 2024 openEuler Community
+ EasySoftware is licensed under the Mulan PSL v2.
+ You can use this software according to the terms and conditions of the Mulan PSL v2.
+ You may obtain a copy of Mulan PSL v2 at:
+     http://license.coscl.org.cn/MulanPSL2
+ THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ See the Mulan PSL v2 for more details.
+*/
+package com.search.docsearch.multirecall.recall.cstrategy;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.search.docsearch.entity.vo.SearchCondition;
+import com.search.docsearch.multirecall.composite.Component;
+import com.search.docsearch.multirecall.recall.SearchStrategy;
+
+public class GSearchStrategy implements SearchStrategy {
+    /**
+     * logger.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(GSearchStrategy.class);
+    
+    /**
+     * roughly filter the recalled results
+     * 
+     * @param SearchCondition paraClient mannage by spring aoc
+     */
+    @Override
+    public Component search(SearchCondition condition) {
+        //writing google search logic here 
+        return null;
+    }
+}

--- a/src/test/java/com/search/docsearch/EsSearchStrategyTest.java
+++ b/src/test/java/com/search/docsearch/EsSearchStrategyTest.java
@@ -1,0 +1,175 @@
+/* Copyright (c) 2024 openEuler Community
+ EasySoftware is licensed under the Mulan PSL v2.
+ You can use this software according to the terms and conditions of the Mulan PSL v2.
+ You may obtain a copy of Mulan PSL v2 at:
+     http://license.coscl.org.cn/MulanPSL2
+ THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ See the Mulan PSL v2 for more details.
+*/
+package com.search.docsearch;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import java.io.IOException;
+import java.util.*;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import com.search.docsearch.config.EsfunctionScoreConfig;
+import com.search.docsearch.entity.vo.SearchCondition;
+import com.search.docsearch.multirecall.composite.Component;
+import com.search.docsearch.multirecall.composite.cdata.EsRecallData;
+import com.search.docsearch.utils.Trie;
+import com.search.docsearch.multirecall.recall.cstrategy.EsSearchStrategy;
+
+@ExtendWith(MockitoExtension.class)
+public class EsSearchStrategyTest {
+
+    /**
+     * the es client
+     * 
+     */
+    @Mock
+    private RestHighLevelClient restHighLevelClient;
+
+    /**
+     * algorithim toolkits
+     * 
+     */
+    @Mock
+    private Trie trie;
+
+    /**
+     * the socre config
+     * 
+     */
+    @Mock
+    private EsfunctionScoreConfig esfunctionScoreConfig;
+
+    /**
+     * es search strategy
+     * 
+     */
+    @InjectMocks
+    private EsSearchStrategy esSearchStrategy;
+
+    /**
+     * search condition from user query
+     * 
+     */
+    private SearchCondition searchCondition;
+
+    /**
+     * intialize mock obejct
+     * 
+     */
+    @BeforeEach
+    void setUp() {
+        searchCondition = new SearchCondition();
+        searchCondition.setKeyword("test");
+        searchCondition.setLang("en");
+        searchCondition.setPage(1);
+        searchCondition.setPageSize(10);
+
+        esSearchStrategy = new EsSearchStrategy(restHighLevelClient, "test_index", trie, esfunctionScoreConfig);
+    }
+
+    /**
+      * 测试: es正常召回
+    */
+    @Test
+    void testSearchWithSuccess() throws IOException {
+        // Mock the search response
+        SearchResponse searchResponse = mock(SearchResponse.class);
+        SearchHits searchHits = mock(SearchHits.class);
+        SearchHit searchHit = mock(SearchHit.class);
+
+        Map<String, Object> mutableMap = new HashMap<>();
+        mutableMap.put("textContent", "This is a test text.");
+        mutableMap.put("title", "Test Title");
+        when(searchResponse.getHits()).thenReturn(searchHits);
+        when(searchHits.getHits()).thenReturn(Collections.singletonList(searchHit).toArray(new SearchHit[0]));
+        when(searchHit.getSourceAsMap()).thenReturn(mutableMap);
+        when(searchHit.getScore()).thenReturn(1.0f);
+    
+        when(restHighLevelClient.search(any(SearchRequest.class), eq(RequestOptions.DEFAULT))).thenReturn(searchResponse);
+
+        // Mock the trie behavior
+        when(trie.getWordSimilarityWithTopSearch(anyString(), anyInt())).thenReturn(1.0);
+
+        // Perform the search
+        Component result = esSearchStrategy.search(searchCondition);
+
+        // Validate the result
+        assertNotNull(result);
+        assertTrue(result instanceof EsRecallData);
+        EsRecallData recallData = (EsRecallData) result;
+        Map<String, Object> data = recallData.getResList();
+        assertNotNull(data); 
+        List<Map<String, Object>> records = (List<Map<String, Object>>) data.get("records");
+        assertNotNull(records);
+        assertEquals(1, records.size());
+        assertEquals("This is a test text.", records.get(0).get("textContent"));
+        assertEquals("Test Title", records.get(0).get("title"));
+    }
+
+    /**
+      * 测试: es 0召回测试
+    */
+    @Test
+    void testSearchWithNoResults() throws IOException {
+        // Mock the search response with no hits
+        SearchResponse searchResponse = mock(SearchResponse.class);
+        SearchHits searchHits = mock(SearchHits.class);
+        SearchHit[] emptyArray = new SearchHit[0];
+
+        when(searchResponse.getHits()).thenReturn(searchHits);
+        when(searchHits.getHits()).thenReturn(emptyArray);
+        when(restHighLevelClient.search(any(SearchRequest.class), eq(RequestOptions.DEFAULT))).thenReturn(searchResponse);
+
+        // Perform the search
+        Component result = esSearchStrategy.search(searchCondition);
+
+        // Validate the result
+        assertNotNull(result);
+        assertTrue(result instanceof EsRecallData);
+        EsRecallData recallData = (EsRecallData) result;
+        Map<String, Object> data = recallData.getResList();
+        assertNotNull(data);
+    }
+
+    /**
+      * 测试: es连接错误测试
+    */
+    @Test
+    void testSearchWithException() throws IOException {
+        // Mock the search to throw an IOException
+        when(restHighLevelClient.search(any(SearchRequest.class), eq(RequestOptions.DEFAULT))).thenThrow(new IOException("Test Exception"));
+
+        // Perform the search
+        Component result = esSearchStrategy.search(searchCondition);
+
+        // Validate the result
+        assertNotNull(result);
+        // Validate the type
+        assertTrue(result instanceof EsRecallData);
+        EsRecallData recallData = (EsRecallData) result;
+        Map<String, Object> data = recallData.getResList();
+        assertNotNull(data);
+    }
+}

--- a/src/test/java/com/search/docsearch/SearchContextTest.java
+++ b/src/test/java/com/search/docsearch/SearchContextTest.java
@@ -1,0 +1,89 @@
+/* Copyright (c) 2024 openEuler Community
+ EasySoftware is licensed under the Mulan PSL v2.
+ You can use this software according to the terms and conditions of the Mulan PSL v2.
+ You may obtain a copy of Mulan PSL v2 at:
+     http://license.coscl.org.cn/MulanPSL2
+ THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ See the Mulan PSL v2 for more details.
+*/
+package com.search.docsearch;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.search.docsearch.entity.vo.SearchCondition;
+import com.search.docsearch.multirecall.composite.DataComposite;
+import com.search.docsearch.multirecall.recall.MultiSearchContext;
+import com.search.docsearch.strategy.ErrorSearchStrategy;
+import com.search.docsearch.strategy.TestSearchStrategy;
+
+
+@SpringBootTest
+public class SearchContextTest {
+
+    /**
+      * 测试: 多路召回数目测试
+    */
+    @Test
+    void testGetMultiSearch() {
+        MultiSearchContext testMultiContext = new MultiSearchContext();
+        TestSearchStrategy testStrategy = new TestSearchStrategy();
+
+        testMultiContext.setSearchStrategy(testStrategy);
+
+        assertEquals(1, testMultiContext.getMultiRecalls());
+    }
+
+    /**
+      * 测试: 多路召回执行异常测试 - 空值condition
+    */
+    @Test
+    void testExecuteMultiSearchWithNull() {
+        MultiSearchContext testMultiContext = new MultiSearchContext();
+        TestSearchStrategy testStrategy = new TestSearchStrategy();
+    
+        testMultiContext.setSearchStrategy(testStrategy);
+        DataComposite testRes = testMultiContext.executeMultiSearch(null);
+        assertEquals(1, testRes.getSize());
+    }
+
+    /**
+      * 测试: 多路召回执行异常测试 - 一路召回失败
+    */
+    @Test
+    void testExecuteMultiSearchWithOneErrors() {
+        MultiSearchContext testMultiContext = new MultiSearchContext();
+        TestSearchStrategy noramlStrategy = new TestSearchStrategy();
+        ErrorSearchStrategy errorStrategy = new ErrorSearchStrategy();
+        SearchCondition testCond = new SearchCondition();
+        testCond.setKeyword("openEuler");
+
+        testMultiContext.setSearchStrategy(noramlStrategy);
+        testMultiContext.setSearchStrategy(errorStrategy);
+
+        DataComposite testRes = testMultiContext.executeMultiSearch(testCond);
+        assertEquals(1, testRes.getSize());
+    }
+
+    /**
+      * 测试: 多路召回执行异常测试 - 全部召回失败
+    */
+    @Test
+    void testExecuteMultiSearchWithALLErrors() {
+        MultiSearchContext testMultiContext = new MultiSearchContext();
+        ErrorSearchStrategy errorStrategy1 = new ErrorSearchStrategy();
+        ErrorSearchStrategy errorStrategy2 = new ErrorSearchStrategy();
+        SearchCondition testCond = new SearchCondition();
+        testCond.setKeyword("openEuler");
+
+        testMultiContext.setSearchStrategy(errorStrategy1);
+        testMultiContext.setSearchStrategy(errorStrategy2);
+
+        DataComposite testRes = testMultiContext.executeMultiSearch(testCond);
+        assertEquals(0, testRes.getSize());
+    }
+
+}

--- a/src/test/java/com/search/docsearch/strategy/ErrorSearchStrategy.java
+++ b/src/test/java/com/search/docsearch/strategy/ErrorSearchStrategy.java
@@ -1,0 +1,28 @@
+/* Copyright (c) 2024 openEuler Community
+ EasySoftware is licensed under the Mulan PSL v2.
+ You can use this software according to the terms and conditions of the Mulan PSL v2.
+ You may obtain a copy of Mulan PSL v2 at:
+     http://license.coscl.org.cn/MulanPSL2
+ THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ See the Mulan PSL v2 for more details.
+*/
+package com.search.docsearch.strategy;
+
+import com.search.docsearch.entity.vo.SearchCondition;
+import com.search.docsearch.multirecall.composite.Component;
+import com.search.docsearch.multirecall.recall.SearchStrategy;
+
+public class ErrorSearchStrategy implements SearchStrategy {
+    /**
+     * roughly filter the recalled results
+     * 
+     * @param SearchCondition paraClient mannage by spring aoc
+     */
+    @Override
+    public Component search(SearchCondition condition) {
+        //return error
+        return null;
+    }
+}

--- a/src/test/java/com/search/docsearch/strategy/TestSearchStrategy.java
+++ b/src/test/java/com/search/docsearch/strategy/TestSearchStrategy.java
@@ -1,0 +1,31 @@
+/* Copyright (c) 2024 openEuler Community
+ EasySoftware is licensed under the Mulan PSL v2.
+ You can use this software according to the terms and conditions of the Mulan PSL v2.
+ You may obtain a copy of Mulan PSL v2 at:
+     http://license.coscl.org.cn/MulanPSL2
+ THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ See the Mulan PSL v2 for more details.
+*/
+package com.search.docsearch.strategy;
+
+import java.util.Collections;
+
+import com.search.docsearch.entity.vo.SearchCondition;
+import com.search.docsearch.multirecall.composite.Component;
+import com.search.docsearch.multirecall.composite.cdata.EsRecallData;
+import com.search.docsearch.multirecall.recall.SearchStrategy;
+
+public class TestSearchStrategy implements SearchStrategy {
+    /**
+     * roughly filter the recalled results
+     * 
+     * @param SearchCondition paraClient mannage by spring aoc
+     */
+    @Override
+    public Component search(SearchCondition condition) {
+        //writing google search logic here 
+        return new EsRecallData(Collections.emptyMap());
+    }
+}


### PR DESCRIPTION
采用策略模式的多路召回框架和es召回策略实现，策略模式横向扩展召回路数，组合容器收集召回结果，并在内部实现粗筛，解耦召回与粗筛逻辑。

src/main/java/com/search/docsearch/multirecall/recall/MultiSearchContext.java  多路召回上下文，执行已经注册的召回策略，并以容器返回结果
src/main/java/com/search/docsearch/multirecall/recall/SearchStrategy.java 召回策略接口类
src/main/java/com/search/docsearch/multirecall/recall/cstrategy/EsSearchStrategy.java es召回具体实现
src/main/java/com/search/docsearch/multirecall/recall/cstrategy/GSearchStrategy.java google召回具体实现（待补充）
src/test/java/com/search/docsearch/EsSearchStrategyTest.java es召回测试类
src/test/java/com/search/docsearch/SearchContextTest.java 召回上下文测试类
src/test/java/com/search/docsearch/strategy/ErrorSearchStrategy.java 错误召回测试类，返回null结果，用于测试n路召回中任意一路召回失败时场景
src/test/java/com/search/docsearch/strategy/TestSearchStrategy.java  正常召回测试类，正常返回结果