### PR TITLE
[feat]加权融合策略、path解析与显示高亮

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,11 @@
             <optional>true</optional>
         </dependency>
 
+        <dependency>
+            <groupId>com.huaban</groupId>
+            <artifactId>jieba-analysis</artifactId>
+            <version>1.0.2</version>
+        </dependency>
 
         <dependency>
             <groupId>org.commonmark</groupId>

--- a/src/main/java/com/search/docsearch/multirecall/composite/DataComposite.java
+++ b/src/main/java/com/search/docsearch/multirecall/composite/DataComposite.java
@@ -97,6 +97,19 @@ public class DataComposite implements Component {
      * 
      */
     public Map<String, Object> mergeResult(){
+        Map<String, Object> baseRes = this.getChild(0).getResList();
+        int pageSize = (int) baseRes.get("pageSize");
+        List<Map<String, Object>> mergedList = weightedMerge(pageSize);
+        baseRes.put("records", mergedList);
+        return baseRes;
+    }   
+
+    /**
+     * merge the other recall results into one way, based one the index 0 of children
+     * 
+     * @return the merged result lists
+     */
+    private Map<String, Object> postionMerge(){
         if (children.size() <= 1) return this.getChild(0).getResList();
 
         Component a = children.get(0);
@@ -114,10 +127,9 @@ public class DataComposite implements Component {
                 aresList.add(pos, bresList.get(pos));
             }
         }
-        
         ares.put("records", aresList);
         return ares;
-    }   
+    }
 
     /**
      * merge the other recall results into one way, based one the index 0 of children

--- a/src/main/java/com/search/docsearch/multirecall/recall/cstrategy/EsSearchStrategy.java
+++ b/src/main/java/com/search/docsearch/multirecall/recall/cstrategy/EsSearchStrategy.java
@@ -160,6 +160,9 @@ public class EsSearchStrategy implements SearchStrategy {
                 else {
                     map.put("score", score*1.0);
                 }
+            } else {
+                Double score = (double) hit.getScore();
+                map.put("score", score);
             }
             if (highlightFields.containsKey("title")) {
                 map.put("title", highlightFields.get("title").getFragments()[0].toString());

--- a/src/main/java/com/search/docsearch/multirecall/recall/cstrategy/GSearchStrategy.java
+++ b/src/main/java/com/search/docsearch/multirecall/recall/cstrategy/GSearchStrategy.java
@@ -18,6 +18,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -139,9 +140,13 @@ public class GSearchStrategy implements SearchStrategy {
                         for (JsonNode termNode : termsNode) {
                             Map<String, Object> map = new HashMap<>();
                             String highlightTittle = highLightContent(condition.getKeyword(),termNode.get("title").asText());
-                            String highlightText = highLightContent(condition.getKeyword(),termNode.get("title").asText());
+                            String highlightText = highLightContent(condition.getKeyword(),termNode.get("snippet").asText());
                             map.put("title", highlightTittle);
-                            map.put("path", termNode.get("link").asText());
+                            String path = termNode.get("link").asText();
+                            path = path.replace("http:", "https:");
+                            map.put("path", path);
+                            String type = parseTypeByPath(path);
+                            map.put("type", type);
                             map.put("textContent", highlightText);
                             if ("lang_en".equals(googleSearchParams.getLr())) {
                                 map.put("lang", "en");
@@ -192,4 +197,30 @@ public class GSearchStrategy implements SearchStrategy {
         return lightContent;
     }
 
+    /**
+     * parse google  path to a type params
+     * 
+     * @param path the google search link
+     * @return type content string
+     */
+    public String parseTypeByPath(String path){
+        String type = "other";
+        HashSet<String> hashSet = new HashSet<>(gProperties.getTypeList());
+        String flag = "zh/";
+        if (path.indexOf(flag) == -1) {
+            flag = "en/";
+        }
+        String[] spliteArray = path.split(flag);
+        if (spliteArray.length < 2) {
+            return type;
+        } else {
+            int index = spliteArray[1].indexOf("/");
+            if (index != -1 && hashSet.contains(spliteArray[1].substring(0, index))) {
+                type = spliteArray[1].substring(0, index);
+            } else {
+                return type;
+            }
+        }
+        return type;
+    }
 }

--- a/src/main/java/com/search/docsearch/properties/GoogleSearchProperties.java
+++ b/src/main/java/com/search/docsearch/properties/GoogleSearchProperties.java
@@ -10,6 +10,8 @@
 */
 package com.search.docsearch.properties;
 
+import java.util.List;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
@@ -33,4 +35,8 @@ public class GoogleSearchProperties {
      * The URL template for the Google Search API.
      */
     private String url;
+    /**
+     * The list of parsing google search link to type.
+     */
+    private List<String> typeList;
 }


### PR DESCRIPTION
src/main/java/com/search/docsearch/multirecall/composite/DataComposite.java 调整为加权融合策略
src/main/java/com/search/docsearch/multirecall/recall/cstrategy/EsSearchStrategy.java bug修复，设置分数，避免后续加权融合报错
src/main/java/com/search/docsearch/multirecall/recall/cstrategy/GSearchStrategy.java jieba分词器与正则显示高亮
src/main/java/com/search/docsearch/multirecall/recall/cstrategy/GSearchStrategy.java 根据linkUrl解析path